### PR TITLE
Change reference docs settings

### DIFF
--- a/openapi/reference.page.yaml
+++ b/openapi/reference.page.yaml
@@ -1,4 +1,6 @@
 type: redoc
 definitionId: petstore
 showInfo: true
-expand: true
+expand: false
+settings:
+  expandResponses: '200,201'


### PR DESCRIPTION
expand - split the API into a page per operation.
expandResponses - specify which responses to expand by default by response codes.