### PR TITLE
demo: show adding an API from the registry

### DIFF
--- a/openapi/example.page.yaml
+++ b/openapi/example.page.yaml
@@ -1,0 +1,4 @@
+type: redoc
+definitionId: example
+showInfo: true
+expand: true

--- a/sidebars.yaml
+++ b/sidebars.yaml
@@ -42,7 +42,7 @@ training:
     expanded: false
     pages:
       - page: openapi/reference.page.yaml/*
-
+  - page: openapi/example.page.yaml
   - group: Admin
     expanded: true
     pages:

--- a/siteConfig.yaml
+++ b/siteConfig.yaml
@@ -6,6 +6,7 @@ headerIcon: ./images/logo.png
 enableToc: true
 oasDefinitions:
   petstore: ./openapi/petstore.yaml
+  example: https://api.redoc.ly/registry/redocly/openapi-demo/v1/bundle/master/openapi.yaml
   # add links to definitions in our API registry by using a fully qualified URL.
 stylesheets:
   - https://fonts.googleapis.com/css?family=Roboto:300,400,600,700


### PR DESCRIPTION
Three steps:

1. Add registry snapshot URL to `siteConfig.yaml` ([how to find your snapshot URL](https://redoc.ly/docs/workflows/api-registry/snapshots/#finding-your-snapshot-links))
2. Add special `.page.yaml` file (I named the one below `example.page.yaml` -- the name must end in `.page.yaml` (so I could have named it `anything.page.yaml` but I could not name it `anything.yaml`.)
3. Add to `sidebars.yaml` (this isn't technically required, but if you want it to display in the sidebar then it would be required).

Prerequisites:

Having your API(s) in the API registry.

---

Note: if your API registry definition is private, to run the developer portal in your local environment, you will need to use the [openapi-cli login command](https://redoc.ly/docs/cli/commands/#login) prior to `yarn start` to run the portal.