### PR TITLE
feat: continuous scroll reference option

### DIFF
--- a/openapi/reference.page.yaml
+++ b/openapi/reference.page.yaml
@@ -1,7 +1,8 @@
+label: Petstore API reference
 type: redoc
 definitionId: petstore
 showInfo: true
-expand: true
+expand: false
 settings:
   generateCodeSamples:
     languages:

--- a/sidebars.yaml
+++ b/sidebars.yaml
@@ -38,10 +38,8 @@ training:
         page: developer-portal/mdx.mdx
       - label: Creating React components
         page: developer-portal/custom-component.mdx
-  - group: Petstore reference
-    expanded: false
-    pages:
-      - page: openapi/reference.page.yaml/*
+
+  - page: openapi/reference.page.yaml
 
   - group: Admin
     expanded: true


### PR DESCRIPTION
I made two changes to the `reference.page.yaml` file to enable continuous scroll:

1. Added a `label` (for the sidebar).
2. Changed `expand` to `false`.

Lines 6-11 of the `reference.page.yaml` show how to enable code sample generation too.