### PR TITLE
Change deprecated headerIcon option

### DIFF
--- a/siteConfig.yaml
+++ b/siteConfig.yaml
@@ -3,7 +3,7 @@ meta:
   description: The best API documentation generator ever.
   siteUrl: https://portal-demo.redoc.ly
   keywords: redocly developer portal, api portal starter, api reference docs
-headerIcon: ./images/logo.png
+logo: ./images/logo.png
 enableToc: true
 oasDefinitions:
   petstore: ./openapi/petstore.yaml


### PR DESCRIPTION
The headerIcon option was deprecated in 1.0.0-beta.139.