### PR TITLE
docs: add info about maximum supported nesting levels

### DIFF
--- a/developer-portal/sidebar-nav.md
+++ b/developer-portal/sidebar-nav.md
@@ -56,12 +56,12 @@ Now, load the upgrade screen and see the sidebar.
 ## Sidebar nesting-levels
 
 Sidebar nesting is controlled by the `group` keyword.
-Groups can be nested within each other.
+Groups can be nested within each other up to 7 levels deep.
 
 Move the upgrade page to display at the very bottom of the sidebar on the left-most side underneath the Petstore reference section.
 
 :::attention
-Pay attention to the indentation spacing
+Pay attention to the indentation spacing.
 :::
 
 ```yaml


### PR DESCRIPTION
This PR adds information about maximum supported nesting levels in sidebar navigation [reported via Slack](https://redoc-ly.slack.com/archives/C01D9NU7R4P/p1630679568014100). 
The same report also mentions that a link is broken, but it works in production and it's formatted properly in the source text, so it might just be mistakenly reported.