### PR TITLE
chore: mention node 16 max

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ## Prerequisites
 
-- [node.js >= 12.22.6](https://nodejs.org/en/)
+- [node.js >= 12.22.6 and <= 16.x](https://nodejs.org/en/)
 - [yarn](https://yarnpkg.com/en/)
 
 ## Install


### PR DESCRIPTION
## What/Why/How?

This portal is not compatible with node 17.

